### PR TITLE
Install guide and optional script for Vim8

### DIFF
--- a/_editors/vim8.liquid
+++ b/_editors/vim8.liquid
@@ -1,0 +1,63 @@
+<a name="vim8"></a>
+<h1>Vim 8</h1>
+
+<p>If you haven't already installed RLS, please see <a href="/install/">this</a> guide.</p>
+
+<p>The installation process described below, including the installation of rustup, rustc, and rls, is codified into a bash script which can be downloaded <a href="/files/install_vimrls.sh">here</a>.</p>
+
+<h3>For Vim-Plug Users</h3>
+<p> Add these lines within your call plug#begin() and call plug#end() block </p>
+<pre class="snippet">
+Plug 'rust-lang/rust.vim'
+Plug 'prabirshrestha/async.vim'
+Plug 'prabirshrestha/vim-lsp'
+Plug 'prabirshrestha/asyncomplete.vim'
+Plug 'prabirshrestha/asyncomplete-lsp.vim'
+</pre>
+
+<p> Then add this block somewhere else in your .vimrc </p>
+<pre class="snippet">
+if executable('rls')
+    au User lsp_setup call lsp#register_server({
+        \ 'name': 'rls',
+        \ 'cmd': {server_info->['rustup', 'run', 'nightly', 'rls']},
+        \ 'whitelist': ['rust'],
+        \ })
+endif
+</pre>
+
+<p> Then in vim, run <p>
+<pre class="snippet">
+ :PlugInstall
+</pre>
+
+<h3>Vanilla Vim8 packages approach</h3>
+
+<p>Make a pack directory under .vim/ if it doesn't already exist. See <a href="https://github.com/vim/vim/blob/master/runtime/doc/repeat.txt#L471">this manual</a> for more information on Vim 8 packages. </p>
+<pre class="snippet">
+ mkdir -p ~/.vim/pack/bundles/start
+</pre>
+
+<p> Then clone these repos into the directory we just created. 
+<pre class="snippet">
+cd ~/.vim/pack/bundles/start
+git clone --depth 1 https://github.com/prabirshrestha/async.vim
+git clone --depth 1 https://github.com/prabirshrestha/vim-lsp
+git clone --depth 1 https://github.com/prabirshrestha/asyncomplete.vim
+git clone --depth 1 https://github.com/prabirshrestha/asyncomplete-lsp.vim
+git clone --depth 1 https://github.com/rust-lang/rust.vim
+</pre>
+
+<p> Then add this block to your .vimrc </p>
+<pre class="snippet">
+if executable('rls')
+    au User lsp_setup call lsp#register_server({
+        \ 'name': 'rls',
+        \ 'cmd': {server_info->['rustup', 'run', 'nightly', 'rls']},
+        \ 'whitelist': ['rust'],
+        \ })
+endif
+</pre>
+
+<p> Also ensure that <strong>filetype plugin indent on</strong> and <strong>syntax enable</strong> are in your .vimrc </p>
+

--- a/_editors/vim8.liquid
+++ b/_editors/vim8.liquid
@@ -3,61 +3,56 @@
 
 <p>If you haven't already installed RLS, please see <a href="/install/">this</a> guide.</p>
 
-<p>The installation process described below, including the installation of rustup, rustc, and rls, is codified into a bash script which can be downloaded <a href="/files/install_vimrls.sh">here</a>.</p>
+<p>The installation process described below, including the installation of rustup, rustc, and rls, is codified into a bash script which can be downloaded <a href="/files/install_vim_rls.sh">here</a>.</p>
 
 <h3>For Vim-Plug Users</h3>
 <p> Add these lines within your call plug#begin() and call plug#end() block </p>
 <pre class="snippet">
-Plug 'rust-lang/rust.vim'
+<span>Plug 'rust-lang/rust.vim'
 Plug 'prabirshrestha/async.vim'
 Plug 'prabirshrestha/vim-lsp'
 Plug 'prabirshrestha/asyncomplete.vim'
 Plug 'prabirshrestha/asyncomplete-lsp.vim'
-</pre>
+</span></pre>
 
 <p> Then add this block somewhere else in your .vimrc </p>
 <pre class="snippet">
-if executable('rls')
+<span>if executable('rls')
     au User lsp_setup call lsp#register_server({
         \ 'name': 'rls',
         \ 'cmd': {server_info->['rustup', 'run', 'nightly', 'rls']},
         \ 'whitelist': ['rust'],
         \ })
-endif
+endif </span>
 </pre>
 
 <p> Then in vim, run <p>
-<pre class="snippet">
- :PlugInstall
-</pre>
+<pre class="snippet"><span>:PlugInstall</span></pre>
 
 <h3>Vanilla Vim8 packages approach</h3>
 
 <p>Make a pack directory under .vim/ if it doesn't already exist. See <a href="https://github.com/vim/vim/blob/master/runtime/doc/repeat.txt#L471">this manual</a> for more information on Vim 8 packages. </p>
 <pre class="snippet">
- mkdir -p ~/.vim/pack/bundles/start
-</pre>
+<span>mkdir -p ~/.vim/pack/bundles/start</span></pre>
 
 <p> Then clone these repos into the directory we just created. 
 <pre class="snippet">
-cd ~/.vim/pack/bundles/start
+<span>cd ~/.vim/pack/bundles/start
 git clone --depth 1 https://github.com/prabirshrestha/async.vim
 git clone --depth 1 https://github.com/prabirshrestha/vim-lsp
 git clone --depth 1 https://github.com/prabirshrestha/asyncomplete.vim
 git clone --depth 1 https://github.com/prabirshrestha/asyncomplete-lsp.vim
-git clone --depth 1 https://github.com/rust-lang/rust.vim
-</pre>
+git clone --depth 1 https://github.com/rust-lang/rust.vim</span></pre>
 
 <p> Then add this block to your .vimrc </p>
 <pre class="snippet">
-if executable('rls')
+<span>if executable('rls')
     au User lsp_setup call lsp#register_server({
         \ 'name': 'rls',
         \ 'cmd': {server_info->['rustup', 'run', 'nightly', 'rls']},
         \ 'whitelist': ['rust'],
         \ })
-endif
-</pre>
+endif</span></pre>
 
 <p> Also ensure that <strong>filetype plugin indent on</strong> and <strong>syntax enable</strong> are in your .vimrc </p>
 

--- a/files/install_vim_rls.sh
+++ b/files/install_vim_rls.sh
@@ -1,0 +1,108 @@
+#!/bin/bash -e
+# Rick Richardson <rick.richardson@gmail.com>
+# License Apache2 or MIT
+
+# * What this does *
+#
+# This script will install RLS and the Vim Language Server Plugin found here :
+# https://github.com/prabirshrestha/vim-lsp
+
+# * Credit *
+#
+# This script incorporates code found in 
+# https://www.reddit.com/r/rust/comments/6rx634/async_autocompletion_for_vim8_and_neovim_via_rls/ 
+# https://github.com/rust-lang-nursery/rls
+# https://github.com/racer-rust/racer#configuration
+
+# * Prereqs *
+# Vim 8  -- On Debian style systems, you can follow the instructions here https://itsfoss.com/vim-8-release-install/
+# curl   -- This one's pretty ubiquitous
+# Rust nightly  -- This script will install it for you, but be warned it will set your default rustup to nightly
+
+# If you are installing rustup and rustc, 
+# I strongly recommend not running this as root, but as your regular
+# logged-in user.  It will install the binaries 
+# It will install rustup,  then rust nightly, then the rust language server
+# After that it will configure a minimal .vim set-up
+# Feel free to comment out the pieces that you don't need
+
+function install_rustup() {
+    rexe=$(which rustup)
+    if [ "$rexe" = "" ]; then
+      curl https://sh.rustup.rs -sSf | sh
+    fi
+}
+
+function install_rustc() {
+    rustup self update
+    rustup update nightly
+    rustup default nightly
+}
+
+function install_rls() {
+    rustup component add rls --toolchain nightly
+    rustup component add rust-analysis --toolchain nightly
+    rustup component add rust-src --toolchain nightly
+}
+
+function install_via_git() {
+    mkdir -p ~/.vim/pack/bundles/start
+    pushd ~/.vim/pack/bundles/start
+    for repo in 'prabirshrestha/async.vim' 'prabirshrestha/vim-lsp' 'prabirshrestha/asyncomplete.vim' 'prabirshrestha/asyncomplete-lsp.vim' 'rust-lang/rust.vim'
+    do
+        git clone --depth 1 https://github.com/${repo} || true
+    done
+
+    popd
+
+    cat << EOF
+vim plugins installed.
+
+Please also add this block to your ~/.vimrc
+
+if executable('rls')
+    au User lsp_setup call lsp#register_server({
+        \ 'name': 'rls',
+        \ 'cmd': {server_info->['rustup', 'run', 'nightly', 'rls']},
+        \ 'whitelist': ['rust'],
+        \ })
+endif
+EOF
+}
+
+function install_via_plug() {
+cat << EOF
+If you have vim-plug installed..."
+Add these lines inside your call plug#begin() and call plug#end() lines in your .vimrc
+Plug 'prabirshrestha/async.vim'
+Plug 'prabirshrestha/vim-lsp'
+Plug 'prabirshrestha/asyncomplete.vim'
+Plug 'prabirshrestha/asyncomplete-lsp.vim'
+
+Also add this code outside of that block.
+
+if executable('rls')
+    au User lsp_setup call lsp#register_server({
+        \ 'name': 'rls',
+        \ 'cmd': {server_info->['rustup', 'run', 'nightly', 'rls']},
+        \ 'whitelist': ['rust'],
+        \ })
+endif
+EOF
+}
+
+# * MAIN *
+
+#install_rustup
+#install_rustc
+install_via_git
+#install_via_plug
+
+RUSTC_ROOT="$(rustc --print sysroot)"
+RUST_SRC_PATH="${RUSTC_ROOT}/lib/rustlib/src/rust/src"
+
+echo "installation completed"
+echo "IMPORTANT : be sure to add this line to your ~/.bashrc"
+echo "export RUST_SRC_PATH=$RUST_SRC_PATH"
+echo "also insure that your path contains the rustc path and cargo path"
+echo "export PATH=$PATH:${RUSTC_ROOT}/bin:~/.cargo/bin

--- a/index.liquid
+++ b/index.liquid
@@ -20,13 +20,15 @@ behind RLS.</p>
 <p>Here are setup instructions for other editors.</p>
 
 <ul>
-    <li><a href="#neovim">Neovim</a></li>    
+    <li><a href="#vim8">Vim 8</a></li>
+    <li><a href="#neovim">Neovim</a></li>
     <li>Atom</li> 
     <li>gnome builder</li> 
     <li>emacs</li> 
-    <li>eclipse</li> 
+    <li>eclipse</li>
 </ul>
 
+{{ include "_editors/vim8.liquid" }}
 
 {{ include "_editors/neovim.liquid" }}
 


### PR DESCRIPTION
This adds a simple guide for installing vim-lsp and helpers into vim.  It also adds an optional install script which can install rustup, rustc, rls and also configure vim8. 