### PR TITLE
Update install instructions (rls->rls-preview)

### DIFF
--- a/pages/install.md
+++ b/pages/install.md
@@ -32,7 +32,7 @@ rustup install nightly
 Once you have rustup installed, run the following commands:
 
 ```
-rustup component add rls --toolchain nightly
+rustup component add rls-preview --toolchain nightly
 rustup component add rust-analysis --toolchain nightly
 rustup component add rust-src --toolchain nightly
 ```


### PR DESCRIPTION
The `rls` component has been renamed to `rls-preview`.